### PR TITLE
#15-리스트 -> 상세화면 이동 기능 추가

### DIFF
--- a/app/src/main/java/me/tiptap/tiptap/common/rx/RxBus.kt
+++ b/app/src/main/java/me/tiptap/tiptap/common/rx/RxBus.kt
@@ -1,0 +1,23 @@
+package me.tiptap.tiptap.common.rx
+
+import io.reactivex.Observable
+import io.reactivex.subjects.BehaviorSubject
+
+class RxBus {
+
+    private val subject = BehaviorSubject.create<Any>()
+
+
+    companion object {
+        private val rxBus = RxBus()
+
+        fun getInstance(): RxBus = rxBus
+    }
+
+
+    fun takeBus(task: Any) = subject.onNext(task)
+
+
+    fun toObservable(): Observable<Any> = subject
+
+}

--- a/app/src/main/java/me/tiptap/tiptap/diaries/DiariesFragment.kt
+++ b/app/src/main/java/me/tiptap/tiptap/diaries/DiariesFragment.kt
@@ -1,5 +1,6 @@
 package me.tiptap.tiptap.diaries
 
+import android.content.Intent
 import android.databinding.DataBindingUtil
 import android.os.Bundle
 import android.support.v4.app.Fragment
@@ -8,11 +9,14 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import me.tiptap.tiptap.R
+import me.tiptap.tiptap.common.rx.RxBus
 import me.tiptap.tiptap.databinding.FragmentDiariesBinding
+import me.tiptap.tiptap.diarydetail.DiaryDetailActivity
 
 class DiariesFragment : Fragment() {
 
     private lateinit var binding: FragmentDiariesBinding
+    private val bus = RxBus.getInstance()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         binding = DataBindingUtil.inflate(inflater, R.layout.fragment_diaries, container, false)
@@ -35,6 +39,8 @@ class DiariesFragment : Fragment() {
 
                 clickSubject.subscribe {
                     //go to detail page.
+                    bus.takeBus(it)
+                    startActivity(Intent(this@DiariesFragment.activity, DiaryDetailActivity::class.java))
                 }
             }
         }

--- a/app/src/main/java/me/tiptap/tiptap/diarydetail/DiaryDetailActivity.kt
+++ b/app/src/main/java/me/tiptap/tiptap/diarydetail/DiaryDetailActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import me.tiptap.tiptap.R
 import me.tiptap.tiptap.databinding.ActivityDiaryDetailBinding
+import me.tiptap.tiptap.util.setupActionBar
 
 class DiaryDetailActivity : AppCompatActivity() {
 
@@ -14,5 +15,9 @@ class DiaryDetailActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = DataBindingUtil.setContentView(this, R.layout.activity_diary_detail)
+
+        setupActionBar(R.id.toolbar) {
+            setDisplayHomeAsUpEnabled(true)
+        }
     }
 }

--- a/app/src/main/java/me/tiptap/tiptap/util/AppCompatActivityExt.kt
+++ b/app/src/main/java/me/tiptap/tiptap/util/AppCompatActivityExt.kt
@@ -1,0 +1,14 @@
+package me.tiptap.tiptap.util
+
+import android.support.annotation.IdRes
+import android.support.v7.app.ActionBar
+import android.support.v7.app.AppCompatActivity
+
+
+fun AppCompatActivity.setupActionBar(@IdRes id : Int, action : ActionBar.() -> Unit){
+    setSupportActionBar(findViewById(id))
+
+    supportActionBar?.run {
+        action()
+    }
+}


### PR DESCRIPTION
1. 데이터를 넘길 수 있는 `RxBus` 클래스 추가 
2. 액티비티 관련 설정 메소드를 담는 `AppCompatActivityExt` 클래스 추가.
3. 툴바 설정 메소드 `setupActionBar` 추가.
4. 리스트의 아이템 클릭 시 `DiaryDetailActivity로 이동하는 기능 추가.