### PR TITLE
#33-Gralde 수정

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,7 +33,7 @@ android {
 }
 
 dependencies {
-    def support_version = "28.0.0-beta01"
+    def support_version = "28.0.0-rc01"
     def constraint_version = "1.1.2"
     def rx_java_version = "2.2.0"
     def rx_android_version = "2.0.2"
@@ -43,10 +43,11 @@ dependencies {
 
     //kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
     kapt "com.android.databinding:compiler:$gradle_version"
 
     //support library
+    implementation "com.android.support:support-v4:$support_version"
+    implementation "com.android.support:support-media-compat:$support_version"
     implementation "com.android.support:appcompat-v7:$support_version"
     implementation "com.android.support:design:$support_version"
     implementation "com.android.support.constraint:constraint-layout:$constraint_version"


### PR DESCRIPTION
1. support_version `28.0.0-beta01` -> `28.0.0-rc01` 으로 업데이트 했습니다.
2. `26.1.0`버전과 중복 된다며 에러발생한 부분을 아래 선언을 통해 해결했습니다.
` implementation "com.android.support:support-v4:$support_version"`
`implementation "com.android.support:support-media-compat:$support_version"`