### PR TITLE
#32-일기 상세화면 삭제 기능 구현

### DIFF
--- a/app/src/main/java/me/tiptap/tiptap/diarydetail/DiaryDetailActivity.kt
+++ b/app/src/main/java/me/tiptap/tiptap/diarydetail/DiaryDetailActivity.kt
@@ -2,7 +2,10 @@ package me.tiptap.tiptap.diarydetail
 
 import android.databinding.DataBindingUtil
 import android.os.Bundle
+import android.support.v7.app.AlertDialog
 import android.support.v7.app.AppCompatActivity
+import android.view.Menu
+import android.view.MenuItem
 import me.tiptap.tiptap.R
 import me.tiptap.tiptap.databinding.ActivityDiaryDetailBinding
 import me.tiptap.tiptap.util.setupActionBar
@@ -19,5 +22,27 @@ class DiaryDetailActivity : AppCompatActivity() {
         setupActionBar(R.id.toolbar) {
             setDisplayHomeAsUpEnabled(true)
         }
+    }
+
+
+    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
+        menuInflater.inflate(R.menu.menu_detail, menu)
+
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == R.id.menu_detail_delete) {
+            AlertDialog.Builder(this).apply {
+                setMessage(R.string.ask_delete)
+                setNegativeButton(R.string.cancel, null)
+                setPositiveButton(R.string.ok) {_, _ ->
+                    finish()
+                }
+
+                show()
+            }
+        }
+        return false
     }
 }

--- a/app/src/main/java/me/tiptap/tiptap/diarywriting/DiaryWritingActivity.kt
+++ b/app/src/main/java/me/tiptap/tiptap/diarywriting/DiaryWritingActivity.kt
@@ -36,7 +36,7 @@ class DiaryWritingActivity : AppCompatActivity()  {
             val input = EditText(this@DiaryWritingActivity)
             alert.setView(input)
 
-            alert.setNegativeButton(R.string.cancle, null)
+            alert.setNegativeButton(R.string.cancel, null)
             alert.setPositiveButton(R.string.ok) { _, _ ->
                 val place = input.text.toString()
                 // Do something with value!

--- a/app/src/main/res/menu/menu_detail.xml
+++ b/app/src/main/res/menu/menu_detail.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android = "http://schemas.android.com/apk/res/android"
+    xmlns:app = "http://schemas.android.com/apk/res-auto"
+    >
+    
+    <item
+        android:id = "@+id/menu_detail_delete"
+        android:title = "@string/delete"
+        app:showAsAction = "always"
+        />
+    
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,5 +5,9 @@
                             Hello Tiptap！\nHello Tiptap！\nHello Tiptap！\nHello Tiptap！\nHello Tiptap！\n</string>
     <string name="location_confirm">위치확인</string>
     <string name="ok">확인</string>
-    <string name="cancle">취소</string>
+    <string name="cancel">취소</string>
+    
+    <!--diary detail-->
+    <string name = "delete">삭제</string>
+    <string name = "ask_delete">삭제하시겠습니까?</string>
 </resources>


### PR DESCRIPTION
1. 삭제 메뉴가 있는 `menu_detail.xml` 추가했습니다.
2. `string.xml`에 "삭제" 문자열 정의했습니다.
3. 삭제 메뉴 클릭 시, 삭제 여부를 묻는 다이얼로그를 띄우고 확인을 클릭하면 `DiariesFragment`로 돌아오도록 구현했습니다.

서버와 연결할 때 다시 테스트 할 예정입니다.