### PR TITLE
#79-스크롤 정상적으로 적용되지 않는 문제 수정

### DIFF
--- a/app/src/main/java/me/tiptap/tiptap/scratch/ScratchFragment.kt
+++ b/app/src/main/java/me/tiptap/tiptap/scratch/ScratchFragment.kt
@@ -3,6 +3,7 @@ package me.tiptap.tiptap.scratch
 import android.annotation.SuppressLint
 import android.content.Context
 import android.databinding.DataBindingUtil
+import android.graphics.Point
 import android.os.Bundle
 import android.support.v4.app.Fragment
 import android.util.Log
@@ -20,19 +21,20 @@ import me.tiptap.tiptap.databinding.FragmentScratchBinding
 
 class ScratchFragment : Fragment() {
 
-    private lateinit var binding : FragmentScratchBinding
+    private lateinit var binding: FragmentScratchBinding
 
     @SuppressLint("ClickableViewAccessibility")
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         binding = DataBindingUtil.inflate(inflater, R.layout.fragment_scratch, container, false)
 
-        binding.layoutScratchMain?.textScratchMainNum?.text = getString(R.string.count_tiptap, 0) //temp
+        setShareMainLayoutSize() // Change share main container's height
 
+        binding.layoutScratchMain?.textScratchMainNum?.text = getString(R.string.count_tiptap, 0) //temp
 
         binding.scratch.setRevealListener(object : ScratchCard.IRevealListener {
             override fun onRevealPercentChangedListener(stv: ScratchCard?, percent: Float) {
                 Log.d("ScratchPer", percent.toString())
-                if(percent == 1.0f) {
+                if (percent == 1.0f) {
                     Log.d("ScratchPer", "Done!")
                     fadeOutAnimation(binding.scratch, 300)
                 }
@@ -43,7 +45,7 @@ class ScratchFragment : Fragment() {
             }
 
         })
-        binding.shareListview.apply {
+        binding.listScratch.apply {
             divider = null
             dividerHeight = 0
             adapter = ListViewAdapter(context)
@@ -51,6 +53,17 @@ class ScratchFragment : Fragment() {
 
         return binding.root
 
+    }
+
+    /**
+     * Change Share main layout container's height to screen size.
+     */
+    private fun setShareMainLayoutSize() {
+        val point = Point()
+
+        activity?.windowManager?.defaultDisplay?.getSize(point)
+
+        binding.containerScratchMain.layoutParams.height = point.y //change height
     }
 
 
@@ -77,7 +90,7 @@ class ScratchFragment : Fragment() {
         internal var sList = arrayOf("#1", "키오스크 카페", "오늘 날씨는 하루종일 맑음. 어제도 오늘도 너무 더워서 아무 생각이 들지 않는다.숙소에서 나와 가장 먼저 들른 곳!")
 
 
-        val mInflator : LayoutInflater = LayoutInflater.from(context)
+        val mInflator: LayoutInflater = LayoutInflater.from(context)
 
 
         override fun getItem(position: Int): Any {

--- a/app/src/main/res/layout/fragment_scratch.xml
+++ b/app/src/main/res/layout/fragment_scratch.xml
@@ -1,66 +1,65 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
-
-    <RelativeLayout
-        android:id="@+id/layout"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
-
+<layout xmlns:android = "http://schemas.android.com/apk/res/android"
+    xmlns:app = "http://schemas.android.com/apk/res-auto"
+    xmlns:tools = "http://schemas.android.com/tools"
+    >
+    
+    <android.support.constraint.ConstraintLayout
+        android:id = "@+id/layout"
+        android:layout_width = "match_parent"
+        android:layout_height = "match_parent"
+        >
+        
         <ScrollView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_alignParentStart="true"
-            android:layout_alignParentTop="true"
-            android:fillViewport="true">
-
-            <!--scratch main-->
-            <RelativeLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content">
-
-                <include
-                    android:id="@+id/layout_scratch_main"
-                    layout="@layout/layout_scratch_main"
-                    android:layout_width="match_parent"
-                    android:layout_height="600dp"
-                    android:layout_marginBottom = "30dp"
-                    android:layout_alignParentStart="true"
-                    android:layout_alignParentTop="true" />
-
+            android:layout_width = "match_parent"
+            android:layout_height = "match_parent"
+            android:fillViewport = "true"
+            >
+            
+            <LinearLayout
+                android:layout_width = "match_parent"
+                android:layout_height = "wrap_content"
+                android:orientation = "vertical"
+                >
+                
+                <!--scratch main container. -->
+                <android.support.constraint.ConstraintLayout
+                    android:id = "@+id/container_scratch_main"
+                    android:layout_width = "match_parent"
+                    android:layout_height = "wrap_content"
+                    >
+                    
+                    <include
+                        android:id = "@+id/layout_scratch_main"
+                        layout = "@layout/layout_scratch_main"
+                        />
+                </android.support.constraint.ConstraintLayout>
+                
                 <me.tiptap.tiptap.scratch.NestedListView
-                    android:id = "@+id/share_listview"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="2dp"
-                    android:layout_below = "@+id/layout_scratch_main"/>
-
-            </RelativeLayout>
-
+                    android:id = "@+id/list_scratch"
+                    android:layout_width = "match_parent"
+                    android:layout_height = "wrap_content"
+                    android:layout_marginBottom = "2dp"
+                    />
+            
+            </LinearLayout>
         </ScrollView>
-
-        <FrameLayout
-            android:id="@+id/layout_container"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
-
-           <me.tiptap.tiptap.scratch.ScratchCard
-                android:id="@+id/scratch"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:background="#00000000"
-                android:gravity="center"
-                android:paddingBottom="50dp"
-                android:paddingLeft="20dp"
-                android:paddingRight="20dp"
-                android:paddingTop="50dp"
-                android:text="@string/scratch_text"
-                android:textColor="@android:color/transparent"
-                android:textSize="20sp" />
-
-        </FrameLayout>
-
-    </RelativeLayout>
+        
+        <!--Scratch card-->
+        <me.tiptap.tiptap.scratch.ScratchCard
+            android:id = "@+id/scratch"
+            android:layout_width = "match_parent"
+            android:layout_height = "match_parent"
+            android:background = "#00000000"
+            android:gravity = "center"
+            android:paddingBottom = "50dp"
+            android:paddingLeft = "20dp"
+            android:paddingRight = "20dp"
+            android:paddingTop = "50dp"
+            android:text = "@string/scratch_text"
+            android:textColor = "@android:color/transparent"
+            android:textSize = "20sp"
+            />
+    
+    </android.support.constraint.ConstraintLayout>
 </layout>


### PR DESCRIPTION
1. `ScrollView`의 child 높이를 `match_parent`로 줄 경우 스크롤이 적용되지 않습니다.
[관련 글](https://teamtreehouse.com/community/scrollview-children-width-and-height)
[stack-overflow](https://stackoverflow.com/questions/5224921/scrollview-ignores-childs-layout-height)

2. include된 `layout_scratch_main.xml`을 감싸는 `ConstraintLayout`인 `container_scratch_main`을 생성했습니다. 
그리고 이 뷰의 높이가 스크린 높이에 맞게 변경되도록 구현했습니다.

기기 테스트 완료!