### PR TITLE
#169-minSDK 19 -> 21로 업그레이드

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,7 @@ android {
     compileSdkVersion 28
     defaultConfig {
         applicationId "me.tiptap.tiptap"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
minSDK를 19에서 21로 업그레이드 했습니다.

이유 : `DatePicker` 커스텀.