### PR TITLE
#151-ScratchFragment 스레드 에러 해결

### DIFF
--- a/app/src/main/java/me/tiptap/tiptap/scratch/ScratchFragment.kt
+++ b/app/src/main/java/me/tiptap/tiptap/scratch/ScratchFragment.kt
@@ -52,8 +52,10 @@ class ScratchFragment : Fragment() {
             }
 
             override fun onRevealed(tv: ScratchCard) {
+                activity?.runOnUiThread {
+                    tv.fadeOutAnimation(binding.scratch, 300)
+                }
                 tv.isRevealed = true
-                tv.fadeOutAnimation(binding.scratch, 300)
 
                 getShareDiary() //get Share diary if scratch is revealed.
             }


### PR DESCRIPTION
에러 내용 : only the original thread that created a view hierarchy can touch its views.

메인스레드가 아닌 곳에서 뷰 작업을 할 때 나타나는 에러.

`ScratchCard`가 reveal된 후 바로 공유 다이어리 API를 호출하는 과정에서 스레드 문제가 발생한 것으로 보임.
[참고](https://stackoverflow.com/questions/45414909/android-only-the-original-thread-that-created-a-view-hierarchy-can-touch-its-vi) 해서 해결함.

SDK24 버전의 에뮬레이터에서 테스트 완료.