### PR TITLE
#179-다이어리 가져오는 API 적용

### DIFF
--- a/app/src/main/java/me/tiptap/tiptap/common/network/DiaryApi.kt
+++ b/app/src/main/java/me/tiptap/tiptap/common/network/DiaryApi.kt
@@ -16,7 +16,7 @@ interface DiaryApi {
 
     //Get DiaryList
     @GET("diary/list")
-    fun diaryList(
+    fun getDiaries(
             @Header("tiptap-token") token: String,
             @Query("page") page: Int,
             @Query("limit") limit: Int):
@@ -24,7 +24,8 @@ interface DiaryApi {
 
 
     //Get Diary List (date)
-    fun diaryListWithDate(
+    @GET("diary/list/by/date")
+    fun getDiariesByDate(
             @Header("tiptap-token") token: String,
             @Query("startDate") startDate: String,
             @Query("endDate") endDate: String

--- a/app/src/main/java/me/tiptap/tiptap/common/network/ServerGenerator.kt
+++ b/app/src/main/java/me/tiptap/tiptap/common/network/ServerGenerator.kt
@@ -19,6 +19,7 @@ class ServerGenerator {
         private fun getClient(): OkHttpClient =
                 OkHttpClient.Builder()
                         .addNetworkInterceptor(StethoInterceptor())
+                        .retryOnConnectionFailure(true)
                         .writeTimeout(WRITE_TIMEOUT, TimeUnit.SECONDS)
                         .readTimeout(READ_TIMEOUT, TimeUnit.SECONDS)
                         .build()

--- a/app/src/main/java/me/tiptap/tiptap/diaries/CalendarActivity.kt
+++ b/app/src/main/java/me/tiptap/tiptap/diaries/CalendarActivity.kt
@@ -41,7 +41,7 @@ class CalendarActivity : AppCompatActivity() {
         val startDate = binding.textCalStart.text
         val endDate = binding.textCalEnd.text
 
-        RxBus.getInstance().takeBus(Pair(startDate, endDate))
+        RxBus.getInstance().takeBus(arrayListOf(startDate, endDate))
     }
 
 

--- a/app/src/main/java/me/tiptap/tiptap/diaries/DiariesAdapter.kt
+++ b/app/src/main/java/me/tiptap/tiptap/diaries/DiariesAdapter.kt
@@ -24,12 +24,29 @@ class DiariesAdapter : RecyclerView.Adapter<DiariesViewHolder>() {
     var isCheckboxAvailable = ObservableBoolean(false)
 
 
+    fun addItemOnTop(item : Diaries) {
+        dataSet[0] = item
+
+        visibleSideHeader(0)
+    }
+
     fun addItems(items: MutableList<Diaries>) {
         dataSet.addAll(items)
         notifyDataSetChanged()
 
-
         visibleSideHeader(dataSet.size - items.size)
+    }
+
+    fun updateItems(items: MutableList<Diaries>) {
+        dataSet.clear()
+        dataSet.addAll(items)
+
+        notifyDataSetChanged()
+    }
+
+    fun deleteAllItems() {
+        dataSet.clear()
+        notifyDataSetChanged()
     }
 
 
@@ -51,16 +68,17 @@ class DiariesAdapter : RecyclerView.Adapter<DiariesViewHolder>() {
         }
     }
 
-    fun startDeleteMode(state : Boolean) {
-        isCheckboxAvailable.set(!state) //change checkbox available or not
+    fun changeDeleteModeState(state: Boolean) {
+        isCheckboxAvailable.set(state) //change checkbox available or not
 
-        if (state) {
-            changeCheckboxState(false)
+        if (!state) {
+            changeCheckboxState(state)
         }
     }
 
+
     fun deleteCheckedItems() {
-        if (checkedDataSet.size > 0) {
+        if (checkedDataSet.isNotEmpty()) {
 
             dataSet.iterator().run {
                 while (this.hasNext()) {
@@ -112,7 +130,7 @@ class DiariesAdapter : RecyclerView.Adapter<DiariesViewHolder>() {
             item.firstLastDiary?.lastDiary?.let {
                 getClickObservable(it).subscribe(clickSubject)
             }
-            getLongClickObservable(isCheckboxAvailable.get()).subscribe(longClickSubject)
+            getLongClickObservable().subscribe(longClickSubject)
             getCheckObservable(item).subscribe(checkSubject)
         }
     }

--- a/app/src/main/java/me/tiptap/tiptap/diaries/DiariesFragment.kt
+++ b/app/src/main/java/me/tiptap/tiptap/diaries/DiariesFragment.kt
@@ -6,12 +6,12 @@ import android.databinding.ObservableBoolean
 import android.os.Bundle
 import android.support.v4.app.Fragment
 import android.support.v7.app.AppCompatActivity
+import android.support.v7.widget.DefaultItemAnimator
 import android.support.v7.widget.LinearLayoutManager
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import com.google.gson.JsonObject
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.observers.DisposableObserver
@@ -31,11 +31,11 @@ class DiariesFragment : Fragment() {
 
     private lateinit var binding: FragmentDiariesBinding
 
-    private var adapter = DiariesAdapter()
+    private val adapter = DiariesAdapter()
 
     private val service = ServerGenerator.createService(DiaryApi::class.java)
     private val rxBus = RxBus.getInstance()
-    private val disposables: CompositeDisposable = CompositeDisposable()
+    private val disposables = CompositeDisposable()
 
     private var totalPage = 0 //total page
 
@@ -55,6 +55,7 @@ class DiariesFragment : Fragment() {
         super.onActivityCreated(savedInstanceState)
 
         initToolbar()
+        initRecyclerView()
     }
 
 
@@ -121,21 +122,40 @@ class DiariesFragment : Fragment() {
                 }
                 .dispose()
     }
+
+    /**
+     * Get diaries by date range.
+     */
+    private fun getDiariesByDate(startDate: String, endDate: String) {
+        disposables.add(
+                service.getDiariesByDate(
+                        TipTapApplication.getAccessToken(), startDate, endDate)
+                        .subscribeOn(Schedulers.io())
+                        .observeOn(AndroidSchedulers.mainThread())
+                        .doOnError { e -> e.printStackTrace() }
+                        .subscribe { t ->
+                            if (t.code == "1000") {
+                                val list = t.data.list
+
+                                if (list.isNotEmpty()) {
+                                    for (monthDiary in list.iterator()) {
+                                        if (monthDiary.diariesOfDay != null) {
+                                            adapter.updateItems(monthDiary.diariesOfDay) //update items
+                                        }
+                                    }
+                                }
                             }
                         }
         )
     }
 
-    private fun getDiaries(page: Int, limit: Int) {
+    private fun getDiaries(page: Int, limit: Int, isDataNotAdded: Boolean) {
+        Log.d("Today", "getDiaries")
         disposables.add(
-                service.diaryList(TipTapApplication.getAccessToken(), page, limit) //한번에 하나의 달만 불러올거.
+                service.getDiaries(TipTapApplication.getAccessToken(), page, limit) //한번에 하나의 달만 불러올거.
                         .observeOn(AndroidSchedulers.mainThread())
                         .subscribeOn(Schedulers.io())
                         .subscribeWith(object : DisposableObserver<DiariesResponse>() {
-                            override fun onComplete() {
-                                adapter.notifyDataSetChanged()
-                            }
-
                             override fun onNext(t: DiariesResponse) {
                                 if (t.code == "1000") {
                                     totalPage = t.data.total
@@ -145,10 +165,19 @@ class DiariesFragment : Fragment() {
                                     if (list.isNotEmpty()) {
                                         for (monthDiary in list.iterator()) {
                                             if (monthDiary.diariesOfDay != null)
-                                                adapter.addItems(monthDiary.diariesOfDay) //add items
+                                                if (!isDataNotAdded && adapter.itemCount != 0) { //금일에 추가된 일기가 있고, 한번 리스트를 로드한 적이 있다면,
+                                                    adapter.addItemOnTop(monthDiary.diariesOfDay[0])
+                                                    return
+                                                } else {
+                                                    adapter.addItems(monthDiary.diariesOfDay) //add items
+                                                }
                                         }
                                     }
                                 }
+                            }
+
+                            override fun onComplete() {
+                                adapter.notifyDataSetChanged()
                             }
 
                             override fun onError(e: Throwable) {
@@ -160,7 +189,17 @@ class DiariesFragment : Fragment() {
 
 
     fun onDateFindButtonClick() {
+        adapter.changeDeleteModeState(false)
+
         startActivity(Intent(this@DiariesFragment.activity, CalendarActivity::class.java))
+    }
+
+
+    fun onDateClearButtonClick() {
+        isDateRangeAvailable.set(false)
+
+        adapter.deleteAllItems()
+        getDiaries(1, 2, true)
     }
 
 
@@ -200,38 +239,52 @@ class DiariesFragment : Fragment() {
         disposables.add(
                 service.deleteDiaryByDay(TipTapApplication.getAccessToken(), invalidDiaries)
                         .subscribeOn(Schedulers.io())
-                        .subscribeWith(object : DisposableObserver<JsonObject>() {
-                            override fun onComplete() {
-                                //
-                            }
-
-                            override fun onNext(t: JsonObject) {
-                                t.apply {
-                                    if (get(getString(R.string.code)).asString != "1000") { //if not successful.
-                                        Log.d(getString(R.string.desc),
-                                                getAsJsonObject(getString(R.string.data)).get(getString(R.string.desc)).asString)
-                                    }
+                        .doOnError { e -> e.printStackTrace() }
+                        .subscribe { t ->
+                            t.apply {
+                                if (get(getString(R.string.code)).asString != "1000") { //if not successful.
+                                    Log.d(getString(R.string.desc), getAsJsonObject(getString(R.string.data)).get(getString(R.string.desc)).asString)
                                 }
                             }
-
-                            override fun onError(e: Throwable) {
-                                e.printStackTrace()
-                            }
                         })
-        )
     }
+
+    override fun setUserVisibleHint(isVisibleToUser: Boolean) {
+        super.setUserVisibleHint(isVisibleToUser)
+
+        if (isVisibleToUser) {
+            if (!isDateRangeAvailable.get()) {
+                checkBus()
+            }
+        } else {
+            resetAllMode()
+            disposables.clear()
+        }
+    }
+
+
+    private fun resetAllMode() {
+        adapter.changeDeleteModeState(false)
+        isBotDialogVisible.set(false)
+
+        isDateRangeAvailable.set(false)
+    }
+
 
     override fun onResume() {
         super.onResume()
 
-        checkBus() //사용자가 날짜 범위를 선택했는지 여부 확인함.
-        initRecyclerView()
+        userVisibleHint = true
 
-        getDiaries(1, 2)
+        if (disposables.size() == 0) {
+            initRecyclerViewEvent()
+        }
     }
 
     override fun onPause() {
         super.onPause()
+
+        resetAllMode()
         disposables.clear()
     }
 

--- a/app/src/main/java/me/tiptap/tiptap/diaries/DiariesFragment.kt
+++ b/app/src/main/java/me/tiptap/tiptap/diaries/DiariesFragment.kt
@@ -55,20 +55,6 @@ class DiariesFragment : Fragment() {
         super.onActivityCreated(savedInstanceState)
 
         initToolbar()
-
-    }
-
-    private fun checkBus() {
-        rxBus.toObservable()
-                .subscribe {
-                    if (it is Pair<*, *>) {
-                        val startDate = it.first
-                        val endDate = it.second
-
-                        isDateRangeAvailable.set(true)
-                        binding.layoutBotRange?.textBotRange?.text = getString(R.string.date_range, startDate, endDate)
-                    }
-                }.dispose()
     }
 
 
@@ -117,6 +103,24 @@ class DiariesFragment : Fragment() {
         }
     }
 
+    private fun checkBus() {
+        rxBus.toObservable()
+                .subscribe {
+                    if (it is ArrayList<*>) {
+                        val startDate = it[0].toString()
+                        val endDate = it[1].toString()
+
+                        isDateRangeAvailable.set(true)
+                        binding.layoutBotRange?.textBotRange?.text = getString(R.string.date_range, startDate, endDate)
+
+                        getDiariesByDate(startDate, endDate)
+
+                    } else if (it is Boolean) {
+                        getDiaries(1, 2, it)
+                    }
+                }
+                .dispose()
+    }
                             }
                         }
         )

--- a/app/src/main/java/me/tiptap/tiptap/diaries/DiariesViewHolder.kt
+++ b/app/src/main/java/me/tiptap/tiptap/diaries/DiariesViewHolder.kt
@@ -20,10 +20,10 @@ class DiariesViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
                 }
             }
 
-    fun getLongClickObservable(item: Boolean): Observable<Boolean> =
+    fun getLongClickObservable(): Observable<Boolean> =
             Observable.create { emitter ->
                 itemView.setOnLongClickListener {
-                    emitter.onNext(item)
+                    emitter.onNext(true)
                     true
                 }
             }

--- a/app/src/main/java/me/tiptap/tiptap/main/MainFragment.kt
+++ b/app/src/main/java/me/tiptap/tiptap/main/MainFragment.kt
@@ -78,6 +78,7 @@ class MainFragment : Fragment() , PreviewDialogNavigator {
 
                             override fun onComplete() {
 
+                                rxBus.takeBus(false)
                             }
 
                             override fun onError(e: Throwable) {

--- a/app/src/main/java/me/tiptap/tiptap/main/MainFragment.kt
+++ b/app/src/main/java/me/tiptap/tiptap/main/MainFragment.kt
@@ -5,6 +5,7 @@ import android.databinding.DataBindingUtil
 import android.databinding.ObservableInt
 import android.os.Bundle
 import android.support.v4.app.Fragment
+import android.support.v7.app.AlertDialog
 import android.support.v7.app.AppCompatActivity
 import android.view.LayoutInflater
 import android.view.View
@@ -28,7 +29,7 @@ import me.tiptap.tiptap.preview.PreviewDialogFragment
 import me.tiptap.tiptap.setting.SettingActivity
 import java.util.*
 
-class MainFragment : Fragment() , PreviewDialogNavigator {
+class MainFragment : Fragment(), PreviewDialogNavigator {
 
     private lateinit var binding: FragmentMainBinding
 
@@ -77,7 +78,6 @@ class MainFragment : Fragment() , PreviewDialogNavigator {
                             }
 
                             override fun onComplete() {
-
                                 rxBus.takeBus(false)
                             }
 
@@ -120,9 +120,9 @@ class MainFragment : Fragment() , PreviewDialogNavigator {
         val tag = view.tag.toString().toInt()
 
         //send diary's idx with diary
-        rxBus.takeBus(Pair(tag, todayDiaries[tag-1] ))
+        rxBus.takeBus(Pair(tag, todayDiaries[tag - 1]))
 
-         PreviewDialogFragment().apply {
+        PreviewDialogFragment().apply {
             previewDialogNavi = this@MainFragment
             show(this@MainFragment.fragmentManager, "preview")  //Show preview dialog
         }
@@ -140,9 +140,19 @@ class MainFragment : Fragment() , PreviewDialogNavigator {
             }
         } else {
             //더이상 다이어리를 적을 수 없음.
+            showWarnDialog()
         }
     }
 
+    private fun showWarnDialog() {
+        this.context?.let {
+            AlertDialog.Builder(it).apply {
+                setMessage(getString(R.string.msg_today_warn))
+                setPositiveButton(getString(R.string.ok), null)
+                create()
+            }.show()
+        }
+    }
 
     /**
      * Setting button is clicked
@@ -173,19 +183,30 @@ class MainFragment : Fragment() , PreviewDialogNavigator {
     }
 
 
+    override fun setUserVisibleHint(isVisibleToUser: Boolean) {
+        super.setUserVisibleHint(isVisibleToUser)
+
+        if (isVisibleToUser) {
+            getTodayDiaries()
+        } else {
+            disposables.clear()
+        }
+    }
+
     override fun onStart() {
         super.onStart()
 
-        getTodayDiaries()
+        userVisibleHint = true
     }
 
 
     override fun onStop() {
         super.onStop()
 
-
         clearResources()
+        disposables.clear()
     }
+
 
     override fun onDestroy() {
         super.onDestroy()

--- a/app/src/main/res/layout/fragment_diaries.xml
+++ b/app/src/main/res/layout/fragment_diaries.xml
@@ -61,6 +61,17 @@
             app:layout_constraintTop_toTopOf = "@+id/gl_diaries_recycler_top"
             />
         
+        
+        <!--bot date range-->
+        <include
+            android:id = "@+id/layout_bot_range"
+            layout = "@layout/layout_bottom_date_range"
+            android:layout_width = "match_parent"
+            android:layout_height = "50dp"
+            android:visibility = "@{(fragment.isDateRangeAvailable &amp;&amp; !fragment.isBotDialogVisible) ? View.VISIBLE : View.GONE}"
+            app:layout_constraintBottom_toBottomOf = "parent"
+            />
+    
         <!--bot dialog-->
         <include
             android:id = "@+id/layout_bot_dialog"
@@ -71,16 +82,5 @@
             app:fragment = "@{fragment}"
             app:layout_constraintBottom_toBottomOf = "parent"
             />
-        
-        <!--bot date range-->
-        <include
-            android:id = "@+id/layout_bot_range"
-            layout = "@layout/layout_bottom_date_range"
-            android:layout_width = "match_parent"
-            android:layout_height = "50dp"
-            android:visibility = "@{fragment.isDateRangeAvailable ? View.VISIBLE : View.GONE}"
-            app:layout_constraintBottom_toBottomOf = "parent"
-            />
-    
     </android.support.constraint.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/layout_post.xml
+++ b/app/src/main/res/layout/layout_post.xml
@@ -42,6 +42,7 @@
             android:id = "@+id/text_post_1"
             style = "@style/PostNumberTextStyle"
             android:text = "@string/post_one"
+            android:visibility = "@{postSize >=1 ? View.VISIBLE : View.INVISIBLE}"
             app:layout_constraintStart_toStartOf = "@+id/gl_post_1"
             />
         
@@ -51,6 +52,7 @@
             android:layout_height = "wrap_content"
             android:onClick = "@{fragment::onPostClick}"
             android:tag = "@string/post_one"
+            android:visibility = "@{postSize >=1 ? View.VISIBLE : View.INVISIBLE}"
             app:layout_constraintEnd_toStartOf = "@+id/img_post_2"
             app:layout_constraintStart_toEndOf = "@+id/text_post_1"
             android:src = "@drawable/stamp7"

--- a/app/src/main/res/layout/toolbar_diaries.xml
+++ b/app/src/main/res/layout/toolbar_diaries.xml
@@ -64,6 +64,7 @@
                 android:layout_height = "wrap_content"
                 android:background = "@android:color/transparent"
                 android:paddingEnd = "22dp"
+                android:onClick="@{() -> fragment.onDateClearButtonClick()}"
                 android:visibility="@{fragment.isDateRangeAvailable ? View.VISIBLE : View.GONE, default = gone}"
                 android:paddingStart = "5dp"
                 android:paddingTop="5dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name = "today">TODAY</string>
     <string name = "no_tiptap">당신의\n첫번째 TIPTAP을\n작성해주세요.</string>
     <string name = "post_count">#%s</string>
+    <string name = "msg_today_warn">하루 TIPTAP은 최대 10개까지 작성할 수 있습니다.</string>
     
     <!--post-->
     <string name = "post_one">01</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -10,6 +10,7 @@
         <item name = "colorPrimaryDark">@color/colorSeafoamBlue</item>
         <item name = "colorAccent">@color/colorAccent</item>
         <item name = "android:homeAsUpIndicator">@drawable/ic_back</item>
+        <item name = "android:actionOverflowButtonStyle">@style/ActionOverflowButtonStyle</item>
         <item name = "android:itemTextAppearance">@style/ItemTextStyle</item>
         <item name = "android:windowFullscreen">true</item>
         <item name = "android:datePickerDialogTheme">@style/BaseDatePickerTheme</item>
@@ -21,6 +22,11 @@
     </style>
 
 
+    <style name = "ActionOverflowButtonStyle"
+        parent = "Widget.AppCompat.ActionButton.Overflow">
+        <item name = "android:tint">@android:color/white</item>
+    </style>
+    
     <style name = "SwitchCompat"
         parent = "Theme.AppCompat.Light">
         <item name = "colorControlActivated">@color/colorSeafoamBlue</item>


### PR DESCRIPTION
1. `DiaryApi`인터페이스의 다이어리 목록을 가져오는 메소드의 이름을 수정했습니다.
*  `diaryList` -> `getDiaries`
*  `diaryListWithDate`  -> `getDiariesByDate`

2. `DiariesFragment`의 `RecyclerView`관련 코드를 수정했습니다.
* dataSet의 최상단만 갱신하는 `addItemOnTop`메소드 추가.
* 리스트 갱신 시 깜빡이는 현상이 나타나지 않도록 default 애니메이션 false로 변경.
* `longClickSubject`가 `isCheckBoxAvailable`의 값을 방출하는 것이 아니라 항상 `true`를 방출하도록 변경.

3. `checkBus()`메소드에 타입 검사 이슈가 있음. `CalendarActivity`에서 `DiariesFragment`로 이동할 때,
`Pair`가 아닌 다른 타입을 방출하도록 수정함.

4. `setUserVisibleHint`를 사용해 API 갱신 시점을 잡도록 수정했습니다.
(뷰 페이저는 앞 뒤 페이지를 미리 생성해놓기 때문에 일반적인 `Fragment` 생명주기로는 시점을 잡기 어려움.)