### PR TITLE
#185-아이템 클릭 이벤트 수정

### DIFF
--- a/app/src/main/java/me/tiptap/tiptap/diaries/DiariesFragment.kt
+++ b/app/src/main/java/me/tiptap/tiptap/diaries/DiariesFragment.kt
@@ -254,8 +254,13 @@ class DiariesFragment : Fragment() {
 
         if (isVisibleToUser) {
             if (!isDateRangeAvailable.get()) {
+                if (disposables.size() == 0) {
+                    initRecyclerViewEvent()
+                }
+
                 checkBus()
             }
+
         } else {
             resetAllMode()
             disposables.clear()


### PR DESCRIPTION
`DiariesFragment`에서 다른 화면으로 이동 후 다시 돌아왔을 때 `RecyclerView`의 아이템 클릭 이벤트가 작동하지 않는 문제를 해결했습니다.


이유 : `setUserVisibleHint`메소드에서 화면이 보이지 않을 때 `CompositDisposable`을 `clear()`하고 
화면이 보일 때 `initRecyclerViewEvent` 메소드를 호출하지 않아 발생함.