### PR TITLE
#212-fix flickering RecyclerView

### DIFF
--- a/app/src/main/java/me/tiptap/tiptap/diaries/DiariesAdapter.kt
+++ b/app/src/main/java/me/tiptap/tiptap/diaries/DiariesAdapter.kt
@@ -13,6 +13,9 @@ import me.tiptap.tiptap.data.Diary
 import java.util.*
 
 class DiariesAdapter : RecyclerView.Adapter<DiariesViewHolder>() {
+    override fun getItemId(position: Int): Long {
+        return dataSet[position].firstLastDiary!!.lastDiary!!.id.toLong()
+    }
 
     private val dataSet: MutableList<Diaries> = mutableListOf()
     val checkedDataSet: MutableList<Date> = mutableListOf() //checked list

--- a/app/src/main/java/me/tiptap/tiptap/diaries/DiariesAdapter.kt
+++ b/app/src/main/java/me/tiptap/tiptap/diaries/DiariesAdapter.kt
@@ -76,16 +76,19 @@ class DiariesAdapter : RecyclerView.Adapter<DiariesViewHolder>() {
 
     fun deleteCheckedItems() {
         if (checkedDataSet.isNotEmpty()) {
-
             dataSet.iterator().run {
                 while (this.hasNext()) {
                     val data = this.next()
+                    val position = dataSet.indexOf(data)
 
                     if (checkedDataSet.contains(data.firstLastDiary?.lastDiary?.createdAt)) {
                         this.remove()
+                        notifyItemChanged(position)
+                    }
+                    if(position == 0) {
+                        visibleSideHeader(0)
                     }
                 }
-                notifyDataSetChanged()
             }
         }
     }

--- a/app/src/main/java/me/tiptap/tiptap/diaries/DiariesFragment.kt
+++ b/app/src/main/java/me/tiptap/tiptap/diaries/DiariesFragment.kt
@@ -72,11 +72,13 @@ class DiariesFragment : Fragment() {
 
     private fun initRecyclerView() {
         binding.recyclerDiaries.apply {
-            layoutManager = LinearLayoutManager(this@DiariesFragment.context)
-            adapter = this@DiariesFragment.adapter
+            val mLayoutManager = LinearLayoutManager(this@DiariesFragment.context)
+            adapter = this@DiariesFragment.adapter.apply {
+                setHasStableIds(true)
+            }
 
+            layoutManager = mLayoutManager
             setHasFixedSize(true)
-            (itemAnimator as DefaultItemAnimator).supportsChangeAnimations = false
 
             initRecyclerViewEvent()
         }


### PR DESCRIPTION
1. 일기 데이터 로드 시 `RecyclerView`의 깜빡임 현상을 해결했습니다.
2. 일기 삭제 시 월(月)의 최상단을 정상적으로 표시하도록 메소드를 수정했습니다..(..!?)

[해결방법참고](https://medium.com/@hanru.yeh/recyclerviews-views-are-blinking-when-notifydatasetchanged-c7b76d5149a2)