### PR TITLE
#220-fix scratch redraw issue.

### DIFF
--- a/app/src/main/java/me/tiptap/tiptap/scratch/ScratchFragment.kt
+++ b/app/src/main/java/me/tiptap/tiptap/scratch/ScratchFragment.kt
@@ -18,6 +18,7 @@ import me.tiptap.tiptap.R
 import me.tiptap.tiptap.TipTapApplication
 import me.tiptap.tiptap.common.network.DiaryApi
 import me.tiptap.tiptap.common.network.ServerGenerator
+import me.tiptap.tiptap.common.view.ScratchCard
 import me.tiptap.tiptap.data.DiaryResponse
 import me.tiptap.tiptap.databinding.FragmentScratchBinding
 
@@ -37,7 +38,7 @@ class ScratchFragment : Fragment() {
     @SuppressLint("ClickableViewAccessibility")
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         binding = DataBindingUtil.inflate(inflater, R.layout.fragment_scratch, container, false)
-        binding.layoutScratchMain?.layoutScratchPost?.postSize = postSize
+        binding.postSize = postSize
 
         initBind()
 
@@ -89,17 +90,16 @@ class ScratchFragment : Fragment() {
                 service.shareDiaries(TipTapApplication.getAccessToken())
                         .observeOn(AndroidSchedulers.mainThread())
                         .subscribeOn(Schedulers.io())
+                        .filter { t -> t.code == "1000" }
                         .subscribeWith(object : DisposableObserver<DiaryResponse>() {
                             override fun onNext(t: DiaryResponse) {
-                                if (t.code == "1000") {
-                                    adapter.addItems(t.data.diaries)
-                                }
+                                adapter.addItems(t.data.diaries)
                             }
 
                             override fun onComplete() {
                                 postSize.set(adapter.itemCount)
 
-                                binding.layoutScratchMain?.apply {
+                                binding.layoutScratchMain.apply {
                                     textScratchMainNum?.text = getString(R.string.count_tiptap, adapter.itemCount)
                                     textScratchMainLocation?.text = adapter.getItem(0).location
                                 }

--- a/app/src/main/java/me/tiptap/tiptap/scratch/ScratchFragment.kt
+++ b/app/src/main/java/me/tiptap/tiptap/scratch/ScratchFragment.kt
@@ -49,17 +49,17 @@ class ScratchFragment : Fragment() {
 
     private fun initBind() {
         binding.scratch.setRevealListener(object : ScratchCard.IRevealListener {
-            override fun onRevealPercentChangedListener(stv: ScratchCard, percent: Float) {
-                if (percent <= 0.2f && !stv.isRevealed) {
-                    stv.mRevealPercent = 1.0f
+            override fun onRevealPercentChangedListener(siv: ScratchCard, percent: Float) {
+                if (percent <= 0.2f && !siv.isRevealed) {
+                    siv.mRevealPercent = 1.0f
                 }
             }
 
-            override fun onRevealed(tv: ScratchCard) {
+            override fun onRevealed(iv: ScratchCard) {
                 activity?.runOnUiThread {
-                    tv.fadeOutAnimation(binding.scratch, 300)
+                    iv.fadeOutAnimation(binding.scratch, 300)
                 }
-                tv.isRevealed = true
+                iv.isRevealed = true
 
                 getShareDiary() //get Share diary if scratch is revealed.
             }
@@ -119,6 +119,16 @@ class ScratchFragment : Fragment() {
 
             layoutManager = LinearLayoutManager(this@ScratchFragment.context)
             adapter = this@ScratchFragment.adapter
+        }
+    }
+
+
+    override fun setUserVisibleHint(isVisibleToUser: Boolean) {
+        if (!isVisibleToUser && postSize.get() > 0) { //if share diary already loaded. and there's more to load
+            adapter.deleteAllItems()
+            postSize.set(0)
+
+            binding.scratch.redrawCover()
         }
     }
 

--- a/app/src/main/java/me/tiptap/tiptap/scratch/SharingAdapter.kt
+++ b/app/src/main/java/me/tiptap/tiptap/scratch/SharingAdapter.kt
@@ -14,10 +14,17 @@ class SharingAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
 
     fun addItems(items: MutableList<Diary>) {
+        val startPosition = itemCount
         dataSet.addAll(items)
-        notifyDataSetChanged()
+
+        notifyItemRangeInserted(startPosition, itemCount)
+
     }
 
+    fun deleteAllItems() {
+        dataSet.clear()
+        notifyDataSetChanged()
+    }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder =
             SharingViewHolder(LayoutInflater.from(parent.context).inflate(R.layout.item_sharing, parent, false))

--- a/app/src/main/res/layout/fragment_scratch.xml
+++ b/app/src/main/res/layout/fragment_scratch.xml
@@ -3,6 +3,11 @@
     xmlns:app = "http://schemas.android.com/apk/res-auto"
     xmlns:tools = "http://schemas.android.com/tools"
     >
+    <data>
+        <variable
+            name = "postSize"
+            type = "android.databinding.ObservableInt"/>
+    </data>
     
     <android.support.constraint.ConstraintLayout
         android:id = "@+id/layout"
@@ -31,6 +36,7 @@
                     
                     <include
                         android:id = "@+id/layout_scratch_main"
+                        postSize="@{postSize}"
                         layout = "@layout/layout_scratch_main"
                         />
                 </android.support.constraint.ConstraintLayout>
@@ -45,7 +51,7 @@
         </ScrollView>
         
         <!--Scratch card-->
-        <me.tiptap.tiptap.scratch.ScratchCard
+        <me.tiptap.tiptap.common.view.ScratchCard
             android:id = "@+id/scratch"
             android:layout_width = "match_parent"
             android:layout_height = "match_parent"

--- a/app/src/main/res/layout/layout_scratch_main.xml
+++ b/app/src/main/res/layout/layout_scratch_main.xml
@@ -4,7 +4,15 @@
     xmlns:app = "http://schemas.android.com/apk/res-auto"
     xmlns:tools = "http://schemas.android.com/tools"
     >
-    
+    <data>
+        <import
+            alias="View"
+            type = "android.view.View"/>
+        <variable
+            name = "postSize"
+            type = "android.databinding.ObservableInt"/>
+    </data>
+
     <android.support.constraint.ConstraintLayout
         android:layout_width = "match_parent"
         android:layout_height = "match_parent"
@@ -25,7 +33,7 @@
             android:layout_height = "wrap_content"
             android:fontFamily = "@font/montserrat_regular"
             android:gravity = "center"
-            android:text = "@{String.format(@string/count_tiptap, 0)}"
+            android:text = "@{postSize == 0 ? String.format(@string/count_tiptap, 0) : String.format(@string/count_tiptap, postSize) }"
             android:textSize = "16sp"
             android:textStyle = "bold"
             app:layout_constraintEnd_toEndOf = "parent"
@@ -93,6 +101,7 @@
             android:fontFamily = "@font/ko_pub_dotum_pl"
             android:textColor = "@color/colorMainGrayIsh"
             android:textSize = "12sp"
+            android:visibility="@{postSize > 0 ? View.VISIBLE : View.GONE}"
             app:layout_constraintEnd_toStartOf = "@+id/gl_scratch_main_side"
             app:layout_constraintStart_toStartOf = "parent"
             app:layout_constraintTop_toBottomOf = "@+id/text_scratch_main_from"
@@ -110,6 +119,7 @@
         <include
             android:id = "@+id/layout_scratch_post"
             layout = "@layout/layout_post"
+            postSize="@{postSize}"
             android:layout_width = "wrap_content"
             android:layout_height = "wrap_content"
             app:layout_constraintStart_toStartOf = "@+id/gl_scratch_post_start"


### PR DESCRIPTION
`MainFragment`에서 `ScratchFragment`로 이동할 때, `ScratchCard`가 다시 보여지도록 수정했습니다.

1.`ScratchCard`를 `ImageView`를 상속받게 변경.
2. `ScratchCard`에 `redrawCover()`메소드 추가.
3. `ScratchFragment`에서 `setUserVisibleHint`메소드를 override해 값이 `false`이면서 `postSize > 0`일 때 
`redrawCover()`메소드를 호출하도록 수정함.