### PR TITLE
#226-Message is modified to be visible when there was no diary.

### DIFF
--- a/app/src/main/java/me/tiptap/tiptap/diaries/DiariesFragment.kt
+++ b/app/src/main/java/me/tiptap/tiptap/diaries/DiariesFragment.kt
@@ -157,6 +157,7 @@ class DiariesFragment : Fragment() {
                                     }
                                 }
                             } else { //there's no diary.
+                                isDiaryExist.set(false)
                                 adapter.deleteAllItems()
                             }
                         }


### PR DESCRIPTION
`get diaries of date range` API를 호출할 때, 해당되는 기간에 일기가 존재하지 않으면
메세지가 정상적으로 보이도록 수정했습니다.