### PR TITLE
#241-Resolve duplicate getDiary API calls.

### DIFF
--- a/app/src/main/java/me/tiptap/tiptap/diaries/DiariesFragment.kt
+++ b/app/src/main/java/me/tiptap/tiptap/diaries/DiariesFragment.kt
@@ -166,12 +166,13 @@ class DiariesFragment : Fragment() {
 
 
     private fun getDiaries(page: Int, limit: Int) {
-        curPage++
-
         disposables.add(
-                service.getDiaries(TipTapApplication.getAccessToken(), page, limit) //한번에 하나의 달만 불러올거.
+                service.getDiaries(TipTapApplication.getAccessToken(), page, limit)
                         .observeOn(AndroidSchedulers.mainThread())
                         .subscribeOn(Schedulers.io())
+                        .doOnSubscribe {
+                            curPage++
+                        }
                         .doOnComplete {
                             if (binding.swipeDiaries.isRefreshing) { //refresh is done.
                                 binding.swipeDiaries.isRefreshing = false


### PR DESCRIPTION
현재 페이지를 + 시켜주는 시점을 변경해 해결했습니다.
s8+ 기기에서 테스트 완료.