### PR TITLE
#289-Apply sharing on/off API 

### DIFF
--- a/app/src/main/java/me/tiptap/tiptap/common/binding/SettingBinding.kt
+++ b/app/src/main/java/me/tiptap/tiptap/common/binding/SettingBinding.kt
@@ -1,0 +1,10 @@
+package me.tiptap.tiptap.common.binding
+
+import android.databinding.BindingAdapter
+import android.widget.CompoundButton
+
+
+@BindingAdapter("setOnCheckedChangeListener")
+fun setOnCheckedChangeListener(view : CompoundButton, listener : CompoundButton.OnCheckedChangeListener) {
+    view.setOnCheckedChangeListener(listener)
+}

--- a/app/src/main/java/me/tiptap/tiptap/common/network/DiaryApi.kt
+++ b/app/src/main/java/me/tiptap/tiptap/common/network/DiaryApi.kt
@@ -93,4 +93,17 @@ interface DiaryApi {
     fun shareDiaries(
             @Header("tiptap-token") token: String
     ): Observable<DiaryResponse>
+
+    //Share on
+    @POST("account/share/on")
+    fun setShareOnDiary(
+            @Header("tiptap-token") token: String
+    ) : Observable<JsonObject>
+
+    //Share off
+    @POST("account/share/off")
+    fun setShareOffDiary(
+            @Header("tiptap-token") token: String
+    ) : Observable<JsonObject>
+
 }

--- a/app/src/main/java/me/tiptap/tiptap/login/LoginActivity.kt
+++ b/app/src/main/java/me/tiptap/tiptap/login/LoginActivity.kt
@@ -50,9 +50,9 @@ class LoginActivity : AppCompatActivity(), LoginNavigator {
      * Save token
      */
     private fun saveToken(token: String) {
-        getSharedPreferences(getString(R.string.auth), Activity.MODE_PRIVATE).apply {
+        getSharedPreferences(getString(R.string.auth_key), Activity.MODE_PRIVATE).apply {
             this.edit().run {
-                putString(getString(R.string.token), token)
+                putString(getString(R.string.token_key), token)
                 apply()
             }
         }

--- a/app/src/main/java/me/tiptap/tiptap/setting/SettingActivity.kt
+++ b/app/src/main/java/me/tiptap/tiptap/setting/SettingActivity.kt
@@ -1,15 +1,26 @@
 package me.tiptap.tiptap.setting
 
+import android.app.Activity
 import android.databinding.DataBindingUtil
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
+import android.util.Log
 import android.view.MenuItem
+import android.widget.CompoundButton
+import com.google.gson.JsonObject
 import com.kakao.network.ErrorResult
 import com.kakao.usermgmt.UserManagement
 import com.kakao.usermgmt.callback.LogoutResponseCallback
 import com.kakao.usermgmt.callback.UnLinkResponseCallback
 import com.kakao.util.helper.log.Logger
+import io.reactivex.Observable
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.schedulers.Schedulers
 import me.tiptap.tiptap.R
+import me.tiptap.tiptap.TipTapApplication
+import me.tiptap.tiptap.common.network.DiaryApi
+import me.tiptap.tiptap.common.network.ServerGenerator
 import me.tiptap.tiptap.databinding.ActivitySettingBinding
 import me.tiptap.tiptap.common.util.redirectLoginActivity
 import me.tiptap.tiptap.common.util.setupActionBar
@@ -18,12 +29,17 @@ class SettingActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivitySettingBinding
 
+    private val service = ServerGenerator.createService(DiaryApi::class.java)
+    private val disposables = CompositeDisposable()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = DataBindingUtil.setContentView(this, R.layout.activity_setting)
         binding.activity = this
 
         initToolbar()
+
+        getShareValue()
     }
 
     private fun initToolbar() {
@@ -32,6 +48,22 @@ class SettingActivity : AppCompatActivity() {
             setDisplayHomeAsUpEnabled(true)
         }
     }
+
+    private fun setDiaryShared(isShared : Boolean) {
+        val observable = when(isShared) {
+            true ->  service.setShareOnDiary(TipTapApplication.getAccessToken())
+            false ->  service.setShareOffDiary(TipTapApplication.getAccessToken())
+        }
+
+        disposables.add(observable
+                .subscribeOn(Schedulers.io())
+                .doOnError { e -> e.printStackTrace() }
+                .filter { task -> task.get(getString(R.string.code)).asString != "1000" }
+                .subscribe { task ->
+                    Log.d(task.get(getString(R.string.code)).asString, task.get(getString(R.string.desc)).asString)
+                })
+    }
+
 
     //logout.
     fun onLogoutButtonClick() {
@@ -42,12 +74,47 @@ class SettingActivity : AppCompatActivity() {
         })
     }
 
+    private fun getShareValue() {
+        getSharedPreferences(getString(R.string.account_key), Activity.MODE_PRIVATE).apply {
+            val shared = getBoolean(getString(R.string.shared_key), true)
+
+            binding.switchSettingShare.isChecked = shared
+        }
+    }
+
+    private fun saveShareValue() {
+        val sharedPref = getSharedPreferences(getString(R.string.account_key), Activity.MODE_PRIVATE)
+
+        with(sharedPref.edit()) {
+            putBoolean(getString(R.string.shared_key), binding.switchSettingShare.isChecked)
+            apply()
+        }
+    }
+
+    //share
+    fun onShareChecked(view: CompoundButton, isChecked: Boolean) {
+        setDiaryShared(isChecked)
+    }
+
     override fun onOptionsItemSelected(item: MenuItem?): Boolean {
         if (item?.itemId == android.R.id.home) {
             onBackPressed()
             return true
         }
         return false
+    }
+
+    override fun onStop() {
+        super.onStop()
+
+        saveShareValue()
+        disposables.clear()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+
+        disposables.dispose()
     }
 
 }

--- a/app/src/main/res/layout/activity_setting.xml
+++ b/app/src/main/res/layout/activity_setting.xml
@@ -46,6 +46,7 @@
 
                 <android.support.v7.widget.SwitchCompat
                     android:id = "@+id/switch_setting_share"
+                    app:setOnCheckedChangeListener="@{activity.onShareChecked}"
                     style = "@style/SettingSwitch"
                     />
             </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,8 +19,8 @@
     <string name = "code">code</string>
     <string name = "data">data</string>
     <string name = "desc">desc</string>
-    <string name = "auth">auth</string>
-    <string name = "token">token</string>
+    <string name = "auth_key">auth</string>
+    <string name = "token_key">token</string>
     <string name="msg_login_denied">다수의 신고로 인해 이용이 정지된 상태입니다.</string>
     
     <!--scratch-->
@@ -67,6 +67,8 @@
     <string name = "setting_share">일기 공유하기</string>
     <string name = "setting_push">푸시알림</string>
     <string name = "logout">로그아웃</string>
+    <string name = "account_key">account</string>
+    <string name= "shared_key">shared</string>
 
     <!--calender-->
     <string name = "select_date">날짜 선택</string>


### PR DESCRIPTION
다이어리의 공유 여부를 on/off하는 API를 적용했습니다. 

1. `DiaryApi` `interface`에 메소드 선언.
2. 공유 여부를 on/off하는 `SwitchCompat`에 `onCheckedChangeListener` 설정함.
3. 공유 여부를 저장하는 `SharedPreference` 선언.
4. api 호출.